### PR TITLE
Ignore IPv6 DNS servers on remote site

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -46,7 +46,7 @@ def resolvconf_nameservers():
     l = []
     for line in open('/etc/resolv.conf'):
         words = line.lower().split()
-        if len(words) >= 2 and words[0] == 'nameserver':
+        if len(words) >= 2 and words[0] == 'nameserver' and words[1].find(':') == -1:
             l.append(words[1])
     return l
 


### PR DESCRIPTION
When getting list of remote DNS servers, we check /etc/resolv.conf
Since we don't support IPv6, ignore any lines that contain ":" in the IP field
